### PR TITLE
Fix ContentValidationMiddleware deep convert to array.

### DIFF
--- a/src/ContentValidationMiddleware.php
+++ b/src/ContentValidationMiddleware.php
@@ -124,11 +124,19 @@ class ContentValidationMiddleware implements MiddlewareInterface
         ], 422);
     }
 
-    private static function object2Array(object $data): array
+    /**
+     * @param object|array $data
+     * @return mixed
+     */
+    private static function object2Array($data)
     {
-        $data = (array) $data;
-        foreach ($data as $key => $value) {
-            if (is_object($value)) {
+        if (is_object($data)) {
+            $data = (array) $data;
+            foreach ($data as $key => $value) {
+                $data[$key] = self::object2Array($value);
+            }
+        } elseif (is_array($data)) {
+            foreach ($data as $key => $value) {
                 $data[$key] = self::object2Array($value);
             }
         }

--- a/src/Opis/TransformersParser.php
+++ b/src/Opis/TransformersParser.php
@@ -14,6 +14,7 @@ use Zfegg\ContentValidation\Opis\Keyword\TransformerKeyword;
 class TransformersParser extends KeywordParser
 {
     use VariablesTrait;
+
     private Resolver\ResolverInterface $resolver;
     private string $type;
 

--- a/src/Opis/TransformersParser.php
+++ b/src/Opis/TransformersParser.php
@@ -15,16 +15,21 @@ class TransformersParser extends KeywordParser
 {
     use VariablesTrait;
     private Resolver\ResolverInterface $resolver;
+    private string $type;
 
-    public function __construct(Resolver\ResolverInterface $resolver)
-    {
-        parent::__construct('$transformers');
+    public function __construct(
+        Resolver\ResolverInterface $resolver,
+        string $keyword = '$transformers',
+        string $type = self::TYPE_BEFORE
+    ) {
+        parent::__construct($keyword);
         $this->resolver = $resolver;
+        $this->type = $type;
     }
 
     public function type(): string
     {
-        return self::TYPE_BEFORE;
+        return $this->type;
     }
 
     public function parse(SchemaInfo $info, SchemaParser $parser, object $shared): ?Keyword

--- a/test/ContentValidationMiddlewareTest.php
+++ b/test/ContentValidationMiddlewareTest.php
@@ -72,7 +72,7 @@ class ContentValidationMiddlewareTest extends TestCase
                     [],
                     [],
                     [],
-                    ['name' => 'foo', 'age' => '18', 'sub' => ['foo' => '123']]
+                    ['name' => 'foo', 'age' => '18', 'sub' => ['foo' => '123'], 'list-obj' => [[['id' => 1]]]]
                 ),
             ],
             'HttpPostInvalid' => [

--- a/test/test.json
+++ b/test/test.json
@@ -58,6 +58,20 @@
           "type": "integer"
         }
       }
+    },
+    "list-obj": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            }
+          }
+        }
+      }
     }
   },
   "required": ["name", "age"],


### PR DESCRIPTION
- `TransformersParser` constructor add `keyword`, `type` args.
- Fix `ContentValidationMiddleware` deep convert to array.